### PR TITLE
Replaced mb_convert_encoding with functions from neitanod/forceutf8.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
         "ext-mbstring": "*",
         "ext-libxml": "*",
         "lib-libxml": ">=2.7.7",
-        "symfony/css-selector": "^3.1"
+        "symfony/css-selector": "^3.1",
+        "neitanod/forceutf8": "~2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "4.6.*",

--- a/src/Document.php
+++ b/src/Document.php
@@ -5,6 +5,8 @@ namespace DOMWrap;
 use DOMWrap\Traits\CommonTrait;
 use DOMWrap\Traits\TraversalTrait;
 use DOMWrap\Traits\ManipulationTrait;
+use ForceUTF8\Encoding as ForceUTF8;
+
 
 /**
  * Document Node
@@ -96,10 +98,8 @@ class Document extends \DOMDocument
 
         if (mb_detect_encoding($html, mb_detect_order(), true) !== 'UTF-8') {
             if (preg_match('@<meta.*?charset=["\']?([^\'"\s]+)@im', $html, $matches)) {
-                $charset = strtoupper($matches[1]);
-
                 $html = preg_replace('@(charset=["\']?)([^\'"\s]+)([^\'"]*[\'"]?)@im', '$1UTF-8$3', $html);
-                $html = mb_convert_encoding($html, 'UTF-8', $charset);
+                $html = ForceUTF8::fixUTF8($html);
             } else {
                 $html = mb_convert_encoding($html, 'UTF-8', 'auto');
             }


### PR DESCRIPTION
Hi,

I replaced mb_convert_encoding, as it doesn't work sometimes (see also https://github.com/scotteh/php-goose/issues/69). neitanod/forceutf8 does a good job as a replacement. Never had any problems after that.

Hope, this one is also okay. :)