### PR TITLE
Fix conversion to utf8

### DIFF
--- a/src/Document.php
+++ b/src/Document.php
@@ -116,7 +116,8 @@ class Document extends \DOMDocument
             $html = mb_convert_encoding($html, 'UTF-8', $charset);
         }
 
-        $this->loadHTML('<?xml encoding="utf-8"?>' . $html);
+        $html = mb_convert_encoding($html, 'HTML-ENTITIES', 'UTF-8');
+        $this->loadHTML($html);
 
         libxml_use_internal_errors($internalErrors);
         libxml_disable_entity_loader($disableEntities);


### PR DESCRIPTION
Hi! I need do a change in your code to translate correct some utf8 characters. The mb_detect_encode was saying my html was utf8, but when i did a find(), or html() the string has encoding problems.

I dont know explain more, i not understand the reason too. All I know is:

I was getting my html via curl, now its come from phantomjs
My php version was 7.0 (your branch 0.*), now is 7.2 and branch 0 or 1 show this problem.

Searching for reasons, i found this: https://stackoverflow.com/questions/39148170/utf-8-with-php-domdocument-loadhtml

I tried change and work fine now. I hope this helpfull (and no break your code).

Thanks.