### PR TITLE
Improve charset matching regex

### DIFF
--- a/src/Document.php
+++ b/src/Document.php
@@ -147,7 +147,7 @@ class Document extends \DOMDocument
             $html = '<domwrap></domwrap>' . $html;
         }
 
-        $result = parent::loadHTML($html, $options);
+        $result = parent::loadHTML('<?xml encoding="utf-8" ?>' . $html, $options);
 
         // Do our re-shuffling of nodes.
         if ($this->libxmlOptions & LIBXML_HTML_NOIMPLIED) {

--- a/src/Document.php
+++ b/src/Document.php
@@ -164,7 +164,7 @@ class Document extends \DOMDocument
     private function getCharset(string $html): ?string {
         $charset = null;
 
-        if (preg_match('@<meta.*?charset=["]?([^"\s]+)@im', $html, $matches)) {
+        if (preg_match('@<meta.*?charset=["\']?([^"\'\s>]+)@im', $html, $matches)) {
             $charset = strtoupper($matches[1]);
         }
 


### PR DESCRIPTION
This PR addresses cases where the meta-charset looks like this:

`<meta charset=utf-8>`
`<meta charset='utf-8'>`