### PR TITLE
Test improvement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.phar
 phpunit.xml
 vendor/
 build/
+.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ jobs:
   fast_finish: true
 
 before_script:
-  - composer install --dev --prefer-source
+  - composer install --prefer-source
 
 script: ./vendor/bin/phpunit --coverage-text

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -2,7 +2,7 @@
 <phpunit bootstrap="vendor/autoload.php"
 		 colors="true">
     <testsuites>
-        <testsuite>
+        <testsuite name="php-dom-wrapper testsuite">
             <directory>tests</directory>
         </testsuite>
     </testsuites>

--- a/tests/Node/DocumentTest.php
+++ b/tests/Node/DocumentTest.php
@@ -16,7 +16,7 @@ class DocumentTest extends \PHPUnit\Framework\TestCase
     public function testDocumentParent() {
         $doc = $this->document('<html></html>');
 
-        $this->assertSame(null, $doc->parent());
+        $this->assertNull($doc->parent());
     }
 
     public function testDocumentParents() {
@@ -35,6 +35,6 @@ class DocumentTest extends \PHPUnit\Framework\TestCase
         $doc = $this->document('<html></html>');
         $clone = $doc->_clone();
 
-        $this->assertSame(null, $clone);
+        $this->assertNull($clone);
     }
 }

--- a/tests/Traversal/EqTest.php
+++ b/tests/Traversal/EqTest.php
@@ -26,7 +26,7 @@ class EqTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf('\DOMNode', $nodes->eq(3));
         $this->assertSame('div', $nodes->eq(3)->nodeName);
 
-        $this->assertSame(null, $nodes->eq(4));
+        $this->assertNull($nodes->eq(4));
 
         $this->assertInstanceOf('\DOMNode', $nodes->eq(-1));
         $this->assertSame('div', $nodes->eq(-1)->nodeName);
@@ -41,6 +41,6 @@ class EqTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('div', $nodes->eq(-4)->nodeName);
         $this->assertSame('example', $nodes->eq(-4)->attr('class'));
 
-        $this->assertSame(null, $nodes->eq(-5));
+        $this->assertNull($nodes->eq(-5));
     }
 }


### PR DESCRIPTION
# Changed log
- Using the `assertNull` to determine expected type is `null`.
- Let the `.phpunit.result.cache` not be under Git version control because it's generated by `phpunit`.
- The `testsuite` tag needs the `name` attribute on `phpunit.xml.dist` file.
The warning message is as follows:

```
PHPUnit 8.5.2 by Sebastian Bergmann and contributors.

  Warning - The configuration file did not pass validation!
  The following problems have been detected:

  Line 5:
  - Element 'testsuite': The attribute 'name' is required but missing.

  Test results may not be as expected.
```

- Removing `--dev` option on `composer install` command, and the deprecated warning message is as follows:

```
You are using the deprecated option "dev". Dev packages are installed by default now.
```