### PR TITLE
Support Symfony 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "ext-mbstring": "*",
         "ext-libxml": "*",
         "lib-libxml": ">=2.7.7",
-        "symfony/css-selector": "^5.0 || ^6.0"
+        "symfony/css-selector": "^5.0 || ^6.0 || ^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0 || ^10.0"


### PR DESCRIPTION
Hi @scotteh,

Symfony 7 has been released.
The CSS Selector package marked as required as not changed in API: https://github.com/symfony/css-selector/blob/7.0/CHANGELOG.md

So I thing we could just bump the require section.