### PR TITLE
Fix error in substituteWith if parent of node is null

### DIFF
--- a/src/Traits/ManipulationTrait.php
+++ b/src/Traits/ManipulationTrait.php
@@ -184,7 +184,9 @@ trait ManipulationTrait
     public function substituteWith(string|NodeList|\DOMNode|callable $input): self {
         $this->manipulateNodesWithInput($input, function($node, $newNodes) {
             foreach ($newNodes as $newNode) {
-                $node->parent()->replaceChild($newNode, $node);
+                if ($node->parent()) {
+                    $node->parent()->replaceChild($newNode, $node);
+                }
             }
         });
 


### PR DESCRIPTION
`Fatal error: Uncaught Error: Call to a member function replaceChild() on null in /vendor/scotteh/php-dom-wrapper/src/Traits/ManipulationTrait.php:187`

could you do a 2.0.6 tag with this fix please ?